### PR TITLE
Workaround for object identifiers in the args

### DIFF
--- a/cache_to_disk/__init__.py
+++ b/cache_to_disk/__init__.py
@@ -237,7 +237,7 @@ def cache_exists(cache_metadata, function_name, *args, **kwargs):
     new_caches_for_function = []
     cache_changed = False
     for function_cache in cache_metadata[function_name]:
-        if function_cache['args'] == str(args) and (
+        if function_cache['args'] == str(args) or (
                 function_cache['kwargs'] == str(kwargs)):
             max_age_days = int(function_cache['max_age_days'])
             file_name = join_path(DISK_CACHE_DIR, function_cache['file_name'])


### PR DESCRIPTION
Support matching on either arguments or keyword arguments so that when the kwargs match it hits no matter what the args contain.